### PR TITLE
Replace `optics` with "plain" Haskell

### DIFF
--- a/game-boy-emulator-hs.cabal
+++ b/game-boy-emulator-hs.cabal
@@ -30,7 +30,6 @@ library
     , bytestring
     , containers
     , mtl
-    , optics
     , sdl2
     , stm
     , time

--- a/game-boy-emulator-hs.cabal
+++ b/game-boy-emulator-hs.cabal
@@ -60,7 +60,6 @@ test-suite game-boy-emulator-hs-test
     , base
     , game-boy-emulator-hs
     , mtl
-    , optics
     , tasty
     , tasty-hunit
     , vector

--- a/src-lib/GameBoy/BitStuff.hs
+++ b/src-lib/GameBoy/BitStuff.hs
@@ -32,11 +32,3 @@ combineBytes hi lo = (fromIntegral hi .<<. 8) .|. fromIntegral lo
 
 splitIntoBytes :: U16 -> (U8, U8)
 splitIntoBytes n = (fromIntegral (n .>>. 8), fromIntegral (n .&. 0xff))
-
-bit :: Int -> Lens' U8 Bool
-bit i =
-    lens
-        (`Bits.testBit` i)
-        ( \n on ->
-            (if on then Bits.setBit else Bits.clearBit) n i
-        )

--- a/src-lib/GameBoy/BitStuff.hs
+++ b/src-lib/GameBoy/BitStuff.hs
@@ -1,11 +1,9 @@
 module GameBoy.BitStuff where
 
 import Data.Bits ((.&.), (.<<.), (.>>.), (.|.))
-import Data.Bits qualified as Bits
 import Data.Int
 import Data.Word
 import Numeric qualified
-import Optics
 
 type U8 = Word8
 type U16 = Word16

--- a/src-lib/GameBoy/CPU.hs
+++ b/src-lib/GameBoy/CPU.hs
@@ -2002,4 +2002,5 @@ dmaTransfer n = do
     bus <- use memoryBus
     -- TODO: use a slice pointing to cartridge memory instead?
     forM_ [0 .. 0xa0 - 1] $ \i ->
-        assign' (memoryBus % oam % byte i) (readByte bus (startAddr + i))
+        -- TODO: improve
+        writeMemory (0xfe00 + i) (readByte bus (startAddr + i))

--- a/src-lib/GameBoy/CPU.hs
+++ b/src-lib/GameBoy/CPU.hs
@@ -1968,7 +1968,7 @@ handleInterrupts = do
     if view masterInterruptEnable s
         then do
             let
-                enabledInterrupts = s._memoryBus._ie
+                enabledInterrupts = s._memoryBus.ie
                 requestedInterrupts = interruptFlags s._memoryBus
             case findInterrupt (filter (Bits.testBit requestedInterrupts) [0 .. 4]) enabledInterrupts of
                 Nothing -> pure 0

--- a/src-lib/GameBoy/Main.hs
+++ b/src-lib/GameBoy/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -69,7 +70,7 @@ mainLoop scrRef buttonsRef = do
     syncInput = do
         buttons <- liftIO $ STM.readTVarIO buttonsRef
         -- unless (Set.null buttons) (liftIO $ print buttons)
-        assign' (memoryBus % gamepadState) buttons
+        modifyBusM $ \bus -> bus{gamepadState = buttons}
 
 -- snapshotBackgroundArea = do
 --     bus <- use memoryBus

--- a/src-lib/GameBoy/Main.hs
+++ b/src-lib/GameBoy/Main.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module GameBoy.Main (main) where
@@ -10,7 +10,6 @@ import Control.Monad
 import Control.Monad.State.Strict
 import Data.IORef
 import Data.Time qualified as Time
-import Optics
 import System.Environment qualified as Environment
 import System.IO
 
@@ -36,7 +35,7 @@ mainLoop scrRef buttonsRef = do
         -- TODO: it feels wrong to start at 0 here
         -- shouldn't we use the superfluous cycles from the frame before?
         oneFrame 0
-        scr <- use preparedScreen
+        scr <- gets (.preparedScreen)
         liftIO $ writeIORef scrRef scr
         if (frames == 59)
             then do
@@ -50,8 +49,14 @@ mainLoop scrRef buttonsRef = do
     oneFrame n = when (n < maxCyclesPerFrame) $ do
         syncInput
         s <- get
+        -- let
+        --     serialControl = readByte s.memoryBus 0xff02
+        --     msg' = if (serialControl == 0x81) then BS.cons (readByte s.memoryBus 0xff01) msg else msg
+        -- when (serialControl == 0x81) $ do
+        --     writeMemory 0xff02 0
+        --     liftIO $ putStrLn $ "DBG: " <> reverse (Char8.unpack msg')
         cycles <-
-            if not $ s ^. halted
+            if not s.halted
                 then do
                     instr <- fetch
                     cycles <- execute instr
@@ -60,8 +65,7 @@ mainLoop scrRef buttonsRef = do
                     pure cycles
                 else do
                     -- liftIO $ putStrLn "  [HALT]"
-                    when (interruptFlags s._memoryBus > 0) $
-                        assign' halted False
+                    when (interruptFlags s.memoryBus > 0) continue
                     pure 4
         updateTimers cycles
         updateGraphics cycles

--- a/src-lib/GameBoy/Main.hs
+++ b/src-lib/GameBoy/Main.hs
@@ -59,7 +59,7 @@ mainLoop scrRef buttonsRef = do
                     pure cycles
                 else do
                     -- liftIO $ putStrLn "  [HALT]"
-                    when (s ^. memoryBus % interruptFlags > 0) $
+                    when (interruptFlags s._memoryBus > 0) $
                         assign' halted False
                     pure 4
         updateTimers cycles

--- a/src-lib/GameBoy/Memory.hs
+++ b/src-lib/GameBoy/Memory.hs
@@ -134,47 +134,51 @@ objEnabled bus = Bits.testBit (lcdc bus) 1
 lcdStatus :: Lens' MemoryBus U8
 lcdStatus = io % byte 0x41
 
-viewportY :: Lens' MemoryBus U8
-viewportY = io % byte 0x42
+viewportY :: MemoryBus -> U8
+viewportY bus = readByte bus 0xff42
 
-viewportX :: Lens' MemoryBus U8
-viewportX = io % byte 0x43
+viewportX :: MemoryBus -> U8
+viewportX bus = readByte bus 0xff43
 
-lyc :: Lens' MemoryBus U8
-lyc = io % byte 0x45
+lyc :: MemoryBus -> U8
+lyc bus = readByte bus 0xff45
 
-windowY :: Lens' MemoryBus U8
-windowY = io % byte 0x4a
+windowY :: MemoryBus -> U8
+windowY bus = readByte bus 0xff4a
 
-windowX :: Lens' MemoryBus U8
-windowX = io % byte 0x4b
+windowX :: MemoryBus -> U8
+windowX bus = readByte bus 0x4ffb
 
-divider :: Lens' MemoryBus U8
-divider = io % byte 0x04
+modifyDivider :: (U8 -> U8) -> MemoryBus -> MemoryBus
+modifyDivider f bus =
+    let orig = readByte bus 0xff04
+    in bus{_io = setByteAt 0x04 bus._io (f orig)}
 
-tima :: Lens' MemoryBus U8
-tima = io % byte 0x05
+tima :: MemoryBus -> U8
+tima bus = readByte bus 0xff05
 
-tma :: Lens' MemoryBus U8
-tma = io % byte 0x06
+modifyTima :: (U8 -> U8) -> MemoryBus -> MemoryBus
+modifyTima f bus =
+    let orig = readByte bus 0xff05
+    in bus{_io = setByteAt 0x05 bus._io (f orig)}
 
-tac :: Lens' MemoryBus U8
-tac = io % byte 0x07
+tma :: MemoryBus -> U8
+tma bus = readByte bus 0xff06
 
-bgPalette :: Lens' MemoryBus U8
-bgPalette = io % byte 0x47
+tac :: MemoryBus -> U8
+tac bus = readByte bus 0xff07
 
-timerEnable :: Lens' MemoryBus Bool
-timerEnable = tac % bit 2
+bgPalette :: MemoryBus -> U8
+bgPalette bus = readByte bus 0xff47
+
+timerEnable :: MemoryBus -> Bool
+timerEnable bus = Bits.testBit (tac bus) 2
 
 interruptFlags :: Lens' MemoryBus U8
 interruptFlags = io % byte 0x0f
 
 timerIntRequested :: Lens' MemoryBus Bool
 timerIntRequested = interruptFlags % bit 2
-
-dma :: Lens' MemoryBus U8
-dma = io % byte 0x46
 
 {- FOURMOLU_DISABLE -}
 

--- a/src-lib/GameBoy/Memory.hs
+++ b/src-lib/GameBoy/Memory.hs
@@ -8,6 +8,7 @@
 
 module GameBoy.Memory where
 
+import Data.Bits qualified as Bits
 import Data.ByteString qualified as BS
 import Data.Char qualified as Char
 import Data.Vector.Unboxed (Vector)
@@ -115,20 +116,20 @@ readU16 bus addr =
 scanline :: MemoryBus -> U8
 scanline bus = readByte bus 0xff44
 
-lcdc :: Lens' MemoryBus U8
-lcdc = io % byte 0x40
+lcdc :: MemoryBus -> U8
+lcdc bus = readByte bus 0xff40
 
-lcdEnable :: Lens' MemoryBus Bool
-lcdEnable = lcdc % bit 7
+lcdEnable :: MemoryBus -> Bool
+lcdEnable bus = Bits.testBit (lcdc bus) 7
 
-displayWindow :: Lens' MemoryBus Bool
-displayWindow = lcdc % bit 5
+displayWindow :: MemoryBus -> Bool
+displayWindow bus = Bits.testBit (lcdc bus) 5
 
-spriteUsesTwoTiles :: Lens' MemoryBus Bool
-spriteUsesTwoTiles = lcdc % bit 2
+spriteUsesTwoTiles :: MemoryBus -> Bool
+spriteUsesTwoTiles bus = Bits.testBit (lcdc bus) 2
 
-objEnabled :: Lens' MemoryBus Bool
-objEnabled = lcdc % bit 1
+objEnabled :: MemoryBus -> Bool
+objEnabled bus = Bits.testBit (lcdc bus) 1
 
 lcdStatus :: Lens' MemoryBus U8
 lcdStatus = io % byte 0x41

--- a/src-lib/GameBoy/PPU.hs
+++ b/src-lib/GameBoy/PPU.hs
@@ -195,10 +195,10 @@ drawSprites = do
     forM_ ([0 .. 39] :: [U16]) $ \sprite -> do
         let
             spriteIndex = sprite * 4 -- 4 bytes per sprite
-            y = bus ^. oam % byte spriteIndex - 16
-            x = bus ^. oam % byte (spriteIndex + 1) - 8
-            tileOffset = bus ^. oam % byte (spriteIndex + 2)
-            attrs = bus ^. oam % byte (spriteIndex + 3)
+            y = oamRead spriteIndex bus - 16
+            x = oamRead (spriteIndex + 1) bus - 8
+            tileOffset = oamRead (spriteIndex + 2) bus
+            attrs = oamRead (spriteIndex + 3) bus
             flipMode = readFlipMode attrs
             currentLine = fromIntegral $ scanline bus
             height = if spriteUsesTwoTiles bus then 16 else 8

--- a/src-lib/GameBoy/PPU.hs
+++ b/src-lib/GameBoy/PPU.hs
@@ -258,7 +258,7 @@ setLcdStatus = do
             assign' screen emptyScreen
             assign' preparedScreen emptyScreen
             assign' scanlineCounter 456
-            modifyBusM $ \bus -> bus{_io = setByteAt 0x44 bus._io 0}
+            modifyBusM $ \bus -> bus{io = setByteAt 0x44 bus.io 0} -- TODO: DIV
             -- TODO refactor mode reading/setting
             -- set vblank mode
             let status' = Bits.setBit (Bits.clearBit status 1) 0
@@ -274,7 +274,7 @@ updateGraphics cycles = do
             then assign' scanlineCounter counter
             else do
                 modifying' scanlineCounter (+ 456)
-                modifyBusM $ \bus -> bus{_io = setByteAt 0x44 bus._io (readByte bus 0xff44 + 1)}
+                modifyBusM $ \bus -> bus{io = setByteAt 0x44 bus.io (readByte bus 0xff44 + 1)} -- TODO: DIV
                 line <- gets (scanline . (._memoryBus))
                 if
                     | line == 144 -> do
@@ -283,5 +283,5 @@ updateGraphics cycles = do
                         assign' screen emptyScreen
                         modifyBusM $ requestInterrupt 0
                     | line > 153 -> do
-                        modifyBusM $ \bus -> bus{_io = setByteAt 0x44 bus._io 0}
+                        modifyBusM $ \bus -> bus{io = setByteAt 0x44 bus.io 0}
                     | otherwise -> pure ()

--- a/src-lib/GameBoy/PPU.hs
+++ b/src-lib/GameBoy/PPU.hs
@@ -108,17 +108,17 @@ translateTileColors palette = \case
 readScanlineColors :: MemoryBus -> ScanlineColors
 readScanlineColors bus =
     let
-        y = bus ^. viewportY
-        x = bus ^. viewportX
-        wy = bus ^. windowY
-        wx = bus ^. windowX - 7
+        y = viewportY bus
+        x = viewportX bus
+        wy = windowY bus
+        wx = windowX bus - 7
         mode = addressingMode bus
         currentLine = scanline bus
         useWindow = displayWindow bus && wy <= currentLine
         tileMapStart = determineTileMapAddr useWindow
         ypos = if useWindow then currentLine - wy else currentLine + y
         vertTileIndexOffset = (toU16 ypos .>>. 3) .<<. 5
-        currentPalette = bus ^. bgPalette
+        currentPalette = bgPalette bus
     in
         -- TODO: "preload" only the necessary tiles, _then_ loop
         ScanlineColors (fromIntegral currentLine) $
@@ -245,7 +245,7 @@ setLcdStatus = do
                 when (objEnabled s._memoryBus) drawSprites
             when (needStatInterrupt && newMode /= oldMode) $
                 assign' (memoryBus % interruptFlags % bit 1) True
-            compareValue <- use (memoryBus % lyc)
+            compareValue <- gets (lyc . (._memoryBus))
             -- coincidence check
             if line == compareValue
                 then do

--- a/src-lib/GameBoy/State.hs
+++ b/src-lib/GameBoy/State.hs
@@ -107,4 +107,7 @@ mkInitialState bus =
 modifyBusM :: (MemoryBus -> MemoryBus) -> GameBoy ()
 modifyBusM fn = modify' $ \s -> s{_memoryBus = fn s._memoryBus}
 
+modifyRegistersM :: (Registers -> Registers) -> GameBoy ()
+modifyRegistersM fn = modify' $ \s -> s{_registers = fn s._registers}
+
 type GameBoy a = StateT CPUState IO a

--- a/src-lib/GameBoy/State.hs
+++ b/src-lib/GameBoy/State.hs
@@ -123,4 +123,7 @@ modifyBusM fn = modify' $ \s -> s{_memoryBus = fn s._memoryBus}
 modifyRegistersM :: (Registers -> Registers) -> GameBoy ()
 modifyRegistersM fn = modify' $ \s -> s{_registers = fn s._registers}
 
+modifyScreenM :: (InMemoryScreen -> InMemoryScreen) -> GameBoy ()
+modifyScreenM f = modify' $ \s -> s{_screen = f s._screen}
+
 type GameBoy a = StateT CPUState IO a

--- a/src-lib/GameBoy/State.hs
+++ b/src-lib/GameBoy/State.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE NoFieldSelectors #-}
@@ -8,11 +8,10 @@
 
 module GameBoy.State where
 
-import Data.Bits ((.&.))
 import Control.Monad.State.Strict
+import Data.Bits ((.&.))
 import Data.Vector (Vector)
 import Data.Vector qualified as Vector
-import Optics
 
 import GameBoy.BitStuff
 import GameBoy.Memory
@@ -33,10 +32,10 @@ data Registers = Registers
     }
     deriving stock (Eq)
 
-bc ::  Registers -> U16
+bc :: Registers -> U16
 bc rs = combineBytes rs.b rs.c
 
-setBC :: U16 -> Registers  -> Registers
+setBC :: U16 -> Registers -> Registers
 setBC n rs =
     let (hi, lo) = splitIntoBytes n
     in rs{b = hi, c = lo}
@@ -44,7 +43,7 @@ setBC n rs =
 de :: Registers -> U16
 de rs = combineBytes rs.d rs.e
 
-setDE :: U16 -> Registers  -> Registers
+setDE :: U16 -> Registers -> Registers
 setDE n rs =
     let (hi, lo) = splitIntoBytes n
     in rs{d = hi, e = lo}
@@ -52,7 +51,7 @@ setDE n rs =
 hl :: Registers -> U16
 hl rs = combineBytes rs.h rs.l
 
-setHL :: U16 -> Registers  -> Registers
+setHL :: U16 -> Registers -> Registers
 setHL n rs =
     let (hi, lo) = splitIntoBytes n
     in rs{h = hi, l = lo}
@@ -60,7 +59,7 @@ setHL n rs =
 af :: Registers -> U16
 af rs = combineBytes rs.a rs.f
 
-setAF :: U16 -> Registers  -> Registers
+setAF :: U16 -> Registers -> Registers
 setAF n rs =
     let (hi, lo) = splitIntoBytes (0xfff0 .&. n)
     in rs{a = hi, f = lo}
@@ -96,8 +95,6 @@ data CPUState = CPUState
     , _halted :: Bool
     }
     deriving stock (Show)
-
-makeLenses ''CPUState
 
 mkInitialState :: MemoryBus -> CPUState
 mkInitialState bus =

--- a/src-lib/GameBoy/State.hs
+++ b/src-lib/GameBoy/State.hs
@@ -86,9 +86,6 @@ data CPUState = CPUState
 
 makeLenses ''CPUState
 
-stackPointer :: Lens' CPUState U16
-stackPointer = registers % sp
-
 mkInitialState :: MemoryBus -> CPUState
 mkInitialState bus =
     CPUState initialRegisters bus 0 1024 True 456 emptyScreen emptyScreen False

--- a/src-lib/GameBoy/State.hs
+++ b/src-lib/GameBoy/State.hs
@@ -18,54 +18,52 @@ import GameBoy.BitStuff
 import GameBoy.Memory
 
 data Registers = Registers
-    { _a :: U8
-    , _b :: U8
-    , _c :: U8
-    , _d :: U8
-    , _e :: U8
-    , _h :: U8
-    , _l :: U8
+    { a :: U8
+    , b :: U8
+    , c :: U8
+    , d :: U8
+    , e :: U8
+    , h :: U8
+    , l :: U8
     , -- TODO: benchmark later whether a simple Haskell value can be used here
       -- to make everything more readable
-      _f :: U8
-    , _pc :: U16
-    , _sp :: U16
+      f :: U8
+    , pc :: U16
+    , sp :: U16
     }
     deriving stock (Eq)
 
-makeLenses ''Registers
-
 bc ::  Registers -> U16
-bc rs = combineBytes rs._b rs._c
+bc rs = combineBytes rs.b rs.c
 
 setBC :: U16 -> Registers  -> Registers
 setBC n rs =
     let (hi, lo) = splitIntoBytes n
-    in rs{_b = hi, _c = lo}
+    in rs{b = hi, c = lo}
 
 de :: Registers -> U16
-de rs = combineBytes rs._d rs._e
+de rs = combineBytes rs.d rs.e
 
 setDE :: U16 -> Registers  -> Registers
 setDE n rs =
     let (hi, lo) = splitIntoBytes n
-    in rs{_d = hi, _e = lo}
+    in rs{d = hi, e = lo}
 
 hl :: Registers -> U16
-hl rs = combineBytes rs._h rs._l
+hl rs = combineBytes rs.h rs.l
 
 setHL :: U16 -> Registers  -> Registers
 setHL n rs =
     let (hi, lo) = splitIntoBytes n
-    in rs{_h = hi, _l = lo}
+    in rs{h = hi, l = lo}
 
 af :: Registers -> U16
-af rs = combineBytes rs._a rs._f
+af rs = combineBytes rs.a rs.f
 
 setAF :: U16 -> Registers  -> Registers
 setAF n rs =
     let (hi, lo) = splitIntoBytes (0xfff0 .&. n)
-    in rs{_a = hi, _f = lo}
+    in rs{a = hi, f = lo}
 
 {- FOURMOLU_DISABLE -}
 instance Show Registers where
@@ -74,8 +72,8 @@ instance Show Registers where
         , " | BC = " , toHex (bc rs)
         , " | DE = " , toHex (de rs)
         , " | HL = " , toHex (hl rs)
-        , " | PC = " , toHex rs._pc
-        , " | SP = " , toHex rs._sp
+        , " | PC = " , toHex rs.pc
+        , " | SP = " , toHex rs.sp
         ]
 {- FOURMOLU_ENABLE -}
 
@@ -107,16 +105,16 @@ mkInitialState bus =
   where
     initialRegisters =
         Registers
-            { _a = 0x1
-            , _b = 0
-            , _c = 0x13
-            , _d = 0
-            , _e = 0xd8
-            , _h = 0x1
-            , _l = 0x4d
-            , _f = 0xb0
-            , _pc = 0x100 -- start without BIOS for now
-            , _sp = 0xfffe
+            { a = 0x1
+            , b = 0
+            , c = 0x13
+            , d = 0
+            , e = 0xd8
+            , h = 0x1
+            , l = 0x4d
+            , f = 0xb0
+            , pc = 0x100 -- start without BIOS for now
+            , sp = 0xfffe
             }
 
 modifyBusM :: (MemoryBus -> MemoryBus) -> GameBoy ()

--- a/src-lib/GameBoy/State.hs
+++ b/src-lib/GameBoy/State.hs
@@ -86,9 +86,6 @@ data CPUState = CPUState
 
 makeLenses ''CPUState
 
-programCounter :: Lens' CPUState U16
-programCounter = registers % pc
-
 stackPointer :: Lens' CPUState U16
 stackPointer = registers % sp
 

--- a/src-lib/GameBoy/State.hs
+++ b/src-lib/GameBoy/State.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -108,5 +109,8 @@ mkInitialState bus =
             , _pc = 0x100 -- start without BIOS for now
             , _sp = 0xfffe
             }
+
+modifyBusM :: (MemoryBus -> MemoryBus) -> GameBoy ()
+modifyBusM fn = modify' $ \s -> s{_memoryBus = fn s._memoryBus}
 
 type GameBoy a = StateT CPUState IO a

--- a/src-lib/GameBoy/State.hs
+++ b/src-lib/GameBoy/State.hs
@@ -84,15 +84,15 @@ emptyScreen = Vector.replicate 144 emptyLine
     emptyLine = Vector.replicate 160 0
 
 data CPUState = CPUState
-    { _registers :: Registers
-    , _memoryBus :: MemoryBus
-    , _dividerCounter :: Int
-    , _timerCounter :: Int
-    , _masterInterruptEnable :: Bool
-    , _scanlineCounter :: Int
-    , _screen :: InMemoryScreen
-    , _preparedScreen :: InMemoryScreen
-    , _halted :: Bool
+    { registers :: Registers
+    , memoryBus :: MemoryBus
+    , dividerCounter :: Int
+    , timerCounter :: Int
+    , masterInterruptEnable :: Bool
+    , scanlineCounter :: Int
+    , screen :: InMemoryScreen
+    , preparedScreen :: InMemoryScreen
+    , halted :: Bool
     }
     deriving stock (Show)
 
@@ -115,12 +115,12 @@ mkInitialState bus =
             }
 
 modifyBusM :: (MemoryBus -> MemoryBus) -> GameBoy ()
-modifyBusM fn = modify' $ \s -> s{_memoryBus = fn s._memoryBus}
+modifyBusM fn = modify' $ \s -> s{memoryBus = fn s.memoryBus}
 
 modifyRegistersM :: (Registers -> Registers) -> GameBoy ()
-modifyRegistersM fn = modify' $ \s -> s{_registers = fn s._registers}
+modifyRegistersM fn = modify' $ \s -> s{registers = fn s.registers}
 
 modifyScreenM :: (InMemoryScreen -> InMemoryScreen) -> GameBoy ()
-modifyScreenM f = modify' $ \s -> s{_screen = f s._screen}
+modifyScreenM f = modify' $ \s -> s{screen = f s.screen}
 
 type GameBoy a = StateT CPUState IO a

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,7 +4,6 @@
 module Main (main) where
 
 import Control.Monad.State.Strict
-import Optics
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -47,21 +46,21 @@ registerTests =
         "Unit tests for the CPU registers"
         [ testCase "Reading from BC" $ do
             let r = emptyRegisters{_b = 0xe, _c = 0x7}
-            view bc r @?= 0x0e07
+            bc r @?= 0x0e07
         , testCase "B and C correct after setting BC" $ do
-            let r = set bc 0x131a emptyRegisters
+            let r = setBC 0x131a emptyRegisters
             (r._b, r._c) @?= (0x13, 0x1a)
         , testCase "Reading from DE" $ do
             let r = emptyRegisters{_d = 0xe, _e = 0x7}
-            view de r @?= 0x0e07
+            de r @?= 0x0e07
         , testCase "D and E correct after setting BC" $ do
-            let r = set de 0x0f1e emptyRegisters
+            let r = setDE 0x0f1e emptyRegisters
             (r._d, r._e) @?= (0x0f, 0x1e)
         , testCase "Reading from HL" $ do
             let r = emptyRegisters{_h = 0xe, _l = 0x7}
-            view hl r @?= 0x0e07
+            hl r @?= 0x0e07
         , testCase "D and E correct after setting HL" $ do
-            let r = set hl 0xf3fe emptyRegisters
+            let r = setHL 0xf3fe emptyRegisters
             (r._h, r._l) @?= (0xf3, 0xfe)
         ]
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -45,23 +45,23 @@ registerTests =
     testGroup
         "Unit tests for the CPU registers"
         [ testCase "Reading from BC" $ do
-            let r = emptyRegisters{_b = 0xe, _c = 0x7}
+            let r = emptyRegisters{b = 0xe, c = 0x7}
             bc r @?= 0x0e07
         , testCase "B and C correct after setting BC" $ do
             let r = setBC 0x131a emptyRegisters
-            (r._b, r._c) @?= (0x13, 0x1a)
+            (r.b, r.c) @?= (0x13, 0x1a)
         , testCase "Reading from DE" $ do
-            let r = emptyRegisters{_d = 0xe, _e = 0x7}
+            let r = emptyRegisters{d = 0xe, e = 0x7}
             de r @?= 0x0e07
         , testCase "D and E correct after setting BC" $ do
             let r = setDE 0x0f1e emptyRegisters
-            (r._d, r._e) @?= (0x0f, 0x1e)
+            (r.d, r.e) @?= (0x0f, 0x1e)
         , testCase "Reading from HL" $ do
-            let r = emptyRegisters{_h = 0xe, _l = 0x7}
+            let r = emptyRegisters{h = 0xe, l = 0x7}
             hl r @?= 0x0e07
         , testCase "D and E correct after setting HL" $ do
             let r = setHL 0xf3fe emptyRegisters
-            (r._h, r._l) @?= (0xf3, 0xfe)
+            (r.h, r.l) @?= (0xf3, 0xfe)
         ]
 
 stackTests :: TestTree


### PR DESCRIPTION
It's hard to compare these things, but we seem to have gained around a >30% speedup getting rid of `optics` overall. I'm pretty surprised at how fast everything still is using them, so I'd definitely do it again in a business/work context.

But what's nice is that we have gained (at least) two other benefits:
1. No need to compile with `-fspecialize-aggressively` and `-fexpose-all-unfoldings` anymore, as the program is now roughly as fast without it. These really seem to have worked wonders for `optics`.
2. Everything compiles faster now (not only due to 1).

Now that they're gone, the transition to `IOVector` for mutability in the memory areas should go much more smoothly. My previous attempt probably failed because I had to change way too much at once (optics are not very compatible with these mutable vectors at first glance, though there's probably ways around that).